### PR TITLE
Add list of HTTP standards

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -8,3 +8,4 @@ asciidoc:
     
 nav:
   - modules/ROOT/nav.adoc
+  - modules/standards/nav.adoc

--- a/modules/standards/nav.adoc
+++ b/modules/standards/nav.adoc
@@ -1,0 +1,4 @@
+* Standards
+** xref:overview.adoc[Introduction]
+** xref:grouped.adoc[Grouped by topic]
+** xref:sorted.adoc[Sorted by title]

--- a/modules/standards/pages/grouped.adoc
+++ b/modules/standards/pages/grouped.adoc
@@ -1,0 +1,24 @@
+// section_id_prefix: sgbt_
+= Standards grouped by topic
+
+ifndef::emojis_included[]
+include::partial$emojis.adoc[]
+endif::[]
+
+This page lists relevant standards grouped by topic.
+It contains the same standards as listed on the page xref:overview.adoc[].
+
+== Legend
+
+include::partial$legend.adoc[]
+
+[#sgbt_http_protocol]
+== HTTP Protocol
+
+include::partial$http-2-rfc-9113.adoc[]
+include::partial$http-3-rfc-9114.adoc[]
+
+=== Deprecated Standards
+include::partial$http-1.0-rfc-1945.adoc[]
+include::partial$http-1.1-rfc-2068.adoc[]
+include::partial$http-1.1-rfc-2616.adoc[]

--- a/modules/standards/pages/overview.adoc
+++ b/modules/standards/pages/overview.adoc
@@ -1,0 +1,8 @@
+= Relevant Standards for APIs
+
+This sections lists all relevant official and unofficial standards relevant for HTTP based APIs.
+
+This section is serves as a collection of references for all those who want to delve deeper into the subject areas for their work.
+
+* xref:grouped.adoc[List of standards grouped by topic]
+* xref:sorted.adoc[List of standards ordered by their title]

--- a/modules/standards/pages/sorted.adoc
+++ b/modules/standards/pages/sorted.adoc
@@ -1,0 +1,21 @@
+// section_id_prefix: ssbt_
+= Standards sorted by title
+
+ifndef::emojis_included[]
+include::partial$emojis.adoc[]
+endif::[]
+
+This page lists relevant standards for HTTP based APIs ordered by its title.
+
+== Legend
+
+include::partial$legend.adoc[]
+
+[#ssbt_standards]
+== Standards
+
+include::partial$http-2-rfc-9113.adoc[]
+include::partial$http-3-rfc-9114.adoc[]
+include::partial$http-1.0-rfc-1945.adoc[]
+include::partial$http-1.1-rfc-2068.adoc[]
+include::partial$http-1.1-rfc-2616.adoc[]

--- a/modules/standards/partials/emojis.adoc
+++ b/modules/standards/partials/emojis.adoc
@@ -1,0 +1,4 @@
+:emojis_included: true
+
+:draft: ✍️
+:obsolete: ⚰️

--- a/modules/standards/partials/http-1.0-rfc-1945.adoc
+++ b/modules/standards/partials/http-1.0-rfc-1945.adoc
@@ -1,0 +1,7 @@
+// RFC 1945 - Hypertext Transfer Protocol -- HTTP/1.0
+
+ifndef::emojis_included[]
+include::partial$emojis.adoc[]
+endif::[]
+
+* https://datatracker.ietf.org/doc/html/rfc1945[Hypertext Transfer Protocol -- HTTP/1.0 - RFC 1945 ({obsolete})^]

--- a/modules/standards/partials/http-1.1-rfc-2068.adoc
+++ b/modules/standards/partials/http-1.1-rfc-2068.adoc
@@ -1,0 +1,7 @@
+// RFC 2068 - Hypertext Transfer Protocol -- HTTP/1.1
+
+ifndef::emojis_included[]
+include::partial$emojis.adoc[]
+endif::[]
+
+* https://datatracker.ietf.org/doc/html/rfc2068[Hypertext Transfer Protocol -- HTTP/1.1 - RFC 2068 ({obsolete})^]

--- a/modules/standards/partials/http-1.1-rfc-2616.adoc
+++ b/modules/standards/partials/http-1.1-rfc-2616.adoc
@@ -1,0 +1,7 @@
+// RFC 2616 - Hypertext Transfer Protocol -- HTTP/1.1
+
+ifndef::emojis_included[]
+include::partial$emojis.adoc[]
+endif::[]
+
+* https://datatracker.ietf.org/doc/html/rfc2616[Hypertext Transfer Protocol -- HTTP/1.1 - RFC 2616 ({obsolete})^]

--- a/modules/standards/partials/http-2-rfc-9113.adoc
+++ b/modules/standards/partials/http-2-rfc-9113.adoc
@@ -1,0 +1,7 @@
+// RFC 9113 - HTTP/2
+
+ifndef::emojis_included[]
+include::partial$emojis.adoc[]
+endif::[]
+
+* https://datatracker.ietf.org/doc/html/rfc9113[HTTP/2 - RFC 9113^]

--- a/modules/standards/partials/http-3-rfc-9114.adoc
+++ b/modules/standards/partials/http-3-rfc-9114.adoc
@@ -1,0 +1,7 @@
+// RFC 9114 - HTTP/3
+
+ifndef::emojis_included[]
+include::partial$emojis.adoc[]
+endif::[]
+
+* https://datatracker.ietf.org/doc/html/rfc9114[HTTP/3 - RFC 9114 ({draft})^]

--- a/modules/standards/partials/legend.adoc
+++ b/modules/standards/partials/legend.adoc
@@ -1,0 +1,4 @@
+|===
+| {draft} | Document or standard is a draft
+| {obsolete} | Document or standard is obsolete and only referenced for completeness
+|===


### PR DESCRIPTION
Added a section to provide relevant standards for HTTP protocols. The initial content lists only the RFCs for the HTTP protocol.