### PR TITLE
Add RFC 8594 - The Sunset HTTP Header Field

### DIFF
--- a/modules/standards/data/http-related-standards.yaml
+++ b/modules/standards/data/http-related-standards.yaml
@@ -29,3 +29,10 @@ standards:
     url: https://datatracker.ietf.org/doc/html/rfc2616
     topics:
       - HTTP Protocol
+  - title: The Sunset HTTP Header Field - RFC 8594
+    year: "2019"
+    status: active
+    url: https://datatracker.ietf.org/doc/html/rfc8594
+    topics:
+      - HTTP Header
+      - Life Cycle Management


### PR DESCRIPTION
Added the RFC for the Sunset HTTP Header Field
to the list of standards for HTTP-based APIs.