### PR TITLE
Add RFC 9745 - The Deprecation HTTP Response Header Field

### DIFF
--- a/modules/standards/data/http-related-standards.yaml
+++ b/modules/standards/data/http-related-standards.yaml
@@ -29,6 +29,13 @@ standards:
     url: https://datatracker.ietf.org/doc/html/rfc2616
     topics:
       - HTTP Protocol
+  - title: The Deprecation HTTP Response Header Field - RFC 8594
+    year: "2019"
+    status: active
+    url: https://datatracker.ietf.org/doc/html/rfc9745
+    topics:
+      - HTTP Header
+      - Life Cycle Management
   - title: The Sunset HTTP Header Field - RFC 8594
     year: "2019"
     status: active


### PR DESCRIPTION
Added the RFC for the The Deprecation HTTP Response Header Field to the list of standards for
HTTP-based APIs.