### PR TITLE
Add RFC 6585 - Additional HTTP Status Codes

### DIFF
--- a/modules/standards/data/http-related-standards.yaml
+++ b/modules/standards/data/http-related-standards.yaml
@@ -1,4 +1,10 @@
 standards:
+  - title: Additional HTTP Status Codes - RFC 6585
+    year: "2012"
+    status: active
+    url: https://datatracker.ietf.org/doc/html/rfc6585
+    topics:
+      - HTTP Protocol
   - title: HTTP/2 - RFC 9113
     year: "2022"
     status: active


### PR DESCRIPTION
Added RFC 6585 specifying additional HTTP status codes like 428 Precondition Required, 429 Too Many Requests, 431 Request Header Fields Too Large, and 511 Network Authentication Required.