### PR TITLE
Add more relevant Standards and Resources to the Module

### DIFF
--- a/modules/standards/bin/validate-data-files.sh
+++ b/modules/standards/bin/validate-data-files.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e -u -o pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+source  ${SCRIPT_DIR}/functions.sh
+
+FIELDS_TO_VALIDATE="title url status type"
+
+for FIELD_TO_VALIDATE in ${FIELDS_TO_VALIDATE}; do
+  echo "Standard missing field ${FIELD_TO_VALIDATE}:"
+  cat modules/standards/data/http-related-standards.yaml \
+    | convert_yaml_to_json \
+    | jq -r '[ .standards.[] ] | sort_by(.title) | map(select(.'${FIELD_TO_VALIDATE}' == null)) | "  " + .[].title'
+
+  echo
+done

--- a/modules/standards/data/http-related-standards.yaml
+++ b/modules/standards/data/http-related-standards.yaml
@@ -3,28 +3,122 @@ standards:
     year: "2012"
     status: active
     url: https://datatracker.ietf.org/doc/html/rfc6585
+    type: Proposed Standard
+    topics:
+      - HTTP Protocol
+  - title: 'Communicating Presentation Information in Internet Messages: The Content-Disposition Header Field - RFC 2183'
+    year: "1997"
+    status: active
+    url: https://datatracker.ietf.org/doc/html/rfc2183
+    type: Proposed Standard
+    topics:
+      - HTTP Header
+  - title: Expect-CT Extension for HTTP
+    year: "2022"
+    status: active
+    url: https://datatracker.ietf.org/doc/html/rfc9163/
+    type: Experimental
+    topics:
+      - HTTP Header
+      - Security
+  - title: Forwarded HTTP Extension - RFC 7239
+    year: "2014"
+    status: active
+    url: https://datatracker.ietf.org/doc/html/rfc7239
+    type: Proposed Standard
+    topics:
+      - HTTP Protocol
+  - title: HTTP Cache-Control Extensions for Stale Content - RFC 5861
+    year: "2011"
+    status: active
+    type: Informational
+    url: https://datatracker.ietf.org/doc/html/rfc5861
+    topics:
+      - Caching
+  - title: HTTP Caching - RFC 9111
+    year: "2022"
+    status: active
+    type: Internet Standard
+    url: https://datatracker.ietf.org/doc/html/rfc9111
+    topics:
+      - Caching
+  - title: HTTP Header Field X-Frame-Options - RFC 7034
+    year: "2013"
+    status: active
+    type: Informational
+    url: https://datatracker.ietf.org/doc/html/rfc7034
+    topics:
+      - Security
+      - HTTP Header
+  - title: HTTP Immutable Responses
+    year: "2017"
+    status: active
+    type: HTTP Immutable Responses
+    url: https://datatracker.ietf.org/doc/html/rfc8246
+    topics:
+      - HTTP Protocol
+  - title: HTTP Origin-Bound Authentication (HOBA) - RFC 7486
+    year: "2015"
+    status: active
+    type: Experimental
+    url: https://datatracker.ietf.org/doc/html/rfc7486
+    topics:
+      - Authentication
+      - Security
+  - title: HTTP Semantics - RFC 9110
+    year: "2022"
+    status: active
+    url: https://datatracker.ietf.org/doc/html/rfc9110
+    type: Internet Standard
+    topics:
+      - HTTP Protocol
+  - title: HTTP State Management Mechanism
+    year: "2011"
+    status: active
+    url: https://datatracker.ietf.org/doc/html/rfc6265
+    type: Proposed Standard
+    topics:
+      - Cookies
+  - title: HTTP/1.1 - RFC 9112
+    year: "2022"
+    status: active
+    url: https://datatracker.ietf.org/doc/html/rfc9112
+    type: Internet Standard
     topics:
       - HTTP Protocol
   - title: HTTP/2 - RFC 9113
     year: "2022"
     status: active
     url: https://datatracker.ietf.org/doc/html/rfc9113
+    type: Proposed Standard
     topics:
       - HTTP Protocol
   - title: HTTP/3 - RFC 9114
     year: "2022"
     status: active
     url: https://datatracker.ietf.org/doc/html/rfc9114
+    type: Proposed Standard
     topics:
       - HTTP Protocol
+  - title: Hyper Text Coffee Pot Control Protocol (HTCPCP/1.0) - RFC 2324
+    year: "1998"
+    status: active
+    type: Informational
+    url: https://datatracker.ietf.org/doc/html/rfc2324
+    topics:
+      - HTTP Protocol
+      - April Joke
+      - Coffee
   - title: Hypertext Transfer Protocol -- HTTP/1.0 - RFC 1945
     year: "1996"
     status: obsolete
+    type: Informational
     url: https://datatracker.ietf.org/doc/html/rfc1945
     topics:
       - HTTP Protocol
   - title: Hypertext Transfer Protocol -- HTTP/1.1 - RFC 2068
     url: https://datatracker.ietf.org/doc/html/rfc2068
+    type: Proposed Standard
     year: "1997"
     status: obsolete
     topics:
@@ -33,19 +127,123 @@ standards:
     year: "1999"
     status: obsolete
     url: https://datatracker.ietf.org/doc/html/rfc2616
+    type: Draft Standard
     topics:
       - HTTP Protocol
+  - title: 'Returning Values from Forms: multipart/form-data - RFC 7578'
+    year: "2015"
+    status: active
+    type: Proposed Standard
+    url: https://datatracker.ietf.org/doc/html/rfc7578
+    topics:
+      - Media Types
+  - title: The "data" URL scheme - RFC 2397
+    year: "1998"
+    status: active
+    url: https://datatracker.ietf.org/doc/html/rfc2397
+    type: Proposed Standard
+    topics:
+      - Identifiers
   - title: The Deprecation HTTP Response Header Field - RFC 8594
     year: "2019"
     status: active
     url: https://datatracker.ietf.org/doc/html/rfc9745
+    type: Proposed Standard
     topics:
       - HTTP Header
       - Life Cycle Management
+  - title: The Hyper Text Coffee Pot Control Protocol for Tea Efflux Appliances (HTCPCP-TEA) - RFC 7168
+    year: "2014"
+    status: active
+    url: https://datatracker.ietf.org/doc/html/rfc7168
+    type: Informational
+    topics:
+      - HTTP Protocol
+      - April Joke
+      - Coffee
   - title: The Sunset HTTP Header Field - RFC 8594
     year: "2019"
     status: active
     url: https://datatracker.ietf.org/doc/html/rfc8594
+    type: Informational
     topics:
       - HTTP Header
       - Life Cycle Management
+  - title: The Transport Layer Security (TLS) Protocol Version 1.2 - RFC 5246
+    year: "2008"
+    status: Proposed Standard
+    url: https://datatracker.ietf.org/doc/html/rfc5246
+    type: Proposed Standard
+    topics:
+      - Security
+  - title: The Transport Layer Security (TLS) Protocol Version 1.3 - RFC 8446
+    year: "2018"
+    status: Proposed Standard
+    url: https://datatracker.ietf.org/doc/html/rfc8446
+    type: Proposed Standard
+    topics:
+      - Security
+  - title: The Web Origin Concept - RFC 6454
+    year: "2011"
+    status: active
+    url: https://datatracker.ietf.org/doc/html/rfc6454
+    type: Proposed Standard
+    topics:
+      - Security
+  - title: The WebSocket Protocol - RFC 6455
+    year: "2011"
+    status: active
+    url: https://datatracker.ietf.org/doc/html/rfc6455
+    type: Proposed Standard
+    topics:
+      - WebSocket
+  - title: Transport Layer Security (TLS) Application-Layer Protocol Negotiation Extension - RFC 7301
+    year: "2014"
+    status: active
+    url: https://datatracker.ietf.org/doc/html/rfc7301
+    type: Proposed Standard
+    topics:
+      - Security
+  - title: 'Uniform Resource Identifier (URI): Generic Syntax - RFC 3986'
+    year: "2005"
+    status: active
+    type: Internet Standard
+    url: https://datatracker.ietf.org/doc/html/rfc3986
+    topics:
+      - Identifiers
+  - title: Upgrading to TLS Within HTTP/1.1 - RFC 2817
+    year: "2000"
+    status: active
+    type: Proposed Standard
+    url: https://datatracker.ietf.org/doc/html/rfc2817
+    topics:
+      - Security
+  - title: Use and Interpretation of HTTP Version Numbers - RFC 2145
+    year: "1997"
+    status: active
+    type: Informational
+    url: https://datatracker.ietf.org/doc/html/rfc2145
+    topics:
+      - Versioning
+      - HTTP Protocol
+  - title: Use of the Content-Disposition Header Field in the Hypertext Transfer Protocol (HTTP) - RFC 6266
+    year: "2011"
+    status: active
+    type: Proposed Standard
+    url: https://datatracker.ietf.org/doc/html/rfc6266
+    topics:
+      - HTTP Header
+  - title: Web Linking - RFC 5988
+    year: "2010"
+    status: obsolete
+    url: https://datatracker.ietf.org/doc/html/rfc5988
+    type: Proposed Standard
+    topics:
+      - Linking
+  - title: Web Linking - RFC 8288
+    year: "2017"
+    status: active
+    type: Proposed Standard
+    url: https://datatracker.ietf.org/doc/html/rfc8288
+    topics:
+      - Linking


### PR DESCRIPTION
Added more links to relevant standards and documents to the module.

* Forwarded HTTP Extension - RFC 7239
* HTTP Cache-Control Extensions for Stale Content - RFC 5861
* HTTP Caching - RFC 9111
* HTTP Header Field X-Frame-Options - RFC 7034
* HTTP Origin-Bound Authentication (HOBA) - RFC 7486
* HTTP Semantics - RFC 9110
* HTTP/1.1 - RFC 9112
* The Transport Layer Security (TLS) Protocol Version 1.2 - RFC 5246
* The Transport Layer Security (TLS) Protocol Version 1.3  RFC 8446
* The WebSocket Protocol - RFC 6455
* Transport Layer Security (TLS) Application-Layer Protocol Negotiation Extension - RFC 7301
* The Web Origin Concept - RFC 6454
* Hyper Text Coffee Pot Control Protocol (HTCPCP/1.0) - RFC 2324
* The Hyper Text Coffee Pot Control Protocol for Tea Efflux Appliances (HTCPCP-TEA) - RFC 7168
* HTTP Immutable Responses
* HTTP State Management Mechanism
* Hyper Text Coffee Pot Control Protocol (HTCPCP/1.0) - RFC 2324
* The "data" URL scheme - RFC 2397
* The Hyper Text Coffee Pot Control Protocol for Tea Efflux Appliances (HTCPCP-TEA) - RFC 7168
* The Transport Layer Security (TLS) Protocol Version 1.3 - RFC 8446
* The Web Origin Concept - RFC 6454
* Uniform Resource Identifier (URI): Generic Syntax - RFC 3986
* Use and Interpretation of HTTP Version Numbers - RFC 2145
* Web Linking - RFC 5988
* Web Linking - RFC 8288
* Communicating Presentation Information in Internet Messages: The Content-Disposition Header Field
* Use of the Content-Disposition Header Field in the Hypertext Transfer Protocol (HTTP) - RFC 6266
* Expect-CT Extension for HTTP
* Upgrading to TLS Within HTTP/1.1 - RFC 2817
* Returning Values from Forms: multipart/form-data - RFC 7578