### PR TITLE
Updated "The Deprecation HTTP Response Header Field - RFC 8594"

### DIFF
--- a/modules/standards/data/http-related-standards.yaml
+++ b/modules/standards/data/http-related-standards.yaml
@@ -145,7 +145,7 @@ standards:
     topics:
       - Identifiers
   - title: The Deprecation HTTP Response Header Field - RFC 8594
-    year: "2019"
+    year: "2025"
     status: active
     url: https://datatracker.ietf.org/doc/html/rfc9745
     type: Proposed Standard


### PR DESCRIPTION
Corrected the year of publication. The RFC has been published in 2025 and not in 2019.