### PR TITLE
Changed the name of the Module

### DIFF
--- a/modules/ROOT/pages/overview.adoc
+++ b/modules/ROOT/pages/overview.adoc
@@ -1,2 +1,2 @@
-= My API Practices Guidelines
+= API Best Practices
 


### PR DESCRIPTION
The new name of the module is now "API Best Practices". This is consistent with the naming of all other modules.