### PR TITLE
Switch to custom UI Bundle

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -10,7 +10,7 @@ content:
 
 ui:
   bundle:
-    url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/HEAD/raw/build/ui-bundle.zip?job=bundle-stable
+    url: https://github.com/obfischer/antora-ui-obfischer/releases/download/2025-04-12/ui-bundle.zip
     snapshot: true
 
 antora:


### PR DESCRIPTION
Replaced the common default UI Bundle for Antora with a custom one, used for all best practice modules.