### PR TITLE
An HTTP Status Code to Report Legal Obstacles - RFC 7725

### DIFF
--- a/modules/standards/data/http-related-standards.yaml
+++ b/modules/standards/data/http-related-standards.yaml
@@ -5,6 +5,14 @@ standards:
     url: https://datatracker.ietf.org/doc/html/rfc6585
     topics:
       - HTTP Protocol
+      - HTTP Response Codes
+  - title: An HTTP Status Code to Report Legal Obstacles - RFC 7725
+    year: "2016"
+    status: active
+    url: https://datatracker.ietf.org/doc/html/rfc7725
+    topics:
+      - HTTP Protocol
+      - HTTP Response Codes
   - title: HTTP/2 - RFC 9113
     year: "2022"
     status: active


### PR DESCRIPTION
Added RFC 7725 which specifies a HTTP status code
for use then a resource access is denied for
legal reasons.