### PR TITLE
Changed text for the page with publications sorted by year

### DIFF
--- a/modules/standards/pages/standards-by-year-of-publication.adoc
+++ b/modules/standards/pages/standards-by-year-of-publication.adoc
@@ -14,7 +14,7 @@ include::partial$legend.adoc[]
 [#ssby_standards]
 == Standards
 
-This page lists all standards referenced by their title.
+This page lists all standards organised by the year of publication.
 
 include::partial$generated-http-related-standards-sorted-by-year.adoc[]
 


### PR DESCRIPTION
The text, describing the content of the page, has
been corrected.