### PR TITLE
Replace jq with yq for sorting

### DIFF
--- a/modules/standards/bin/sort-data-files.sh
+++ b/modules/standards/bin/sort-data-files.sh
@@ -9,9 +9,8 @@ source  ${SCRIPT_DIR}/functions.sh
 tempfile=$(mktemp)
 
 cat modules/standards/data/http-related-standards.yaml \
-  | convert_yaml_to_json \
-  | jq '[ .standards.[] ] | sort_by(.title) | {standards: . }' \
-  | yq -p=json > ${tempfile}
+  | yq '.standards |= sort_by(.title) ' \
+  > ${tempfile}
 
 if diff ${tempfile} modules/standards/data/http-related-standards.yaml; then
   IS_UNSORTED=0


### PR DESCRIPTION
The script to ensure the sorting of the
data file for HTTP standards uses now yq to
sort the file instead of jq.

Using yq allows you to skip the conversion to
JSON and then back to YAML. yq keeps the
structure of the YAML document as it
handles YAML natively.