### PR TITLE
Avoid linebreak between title and emoji

### DIFF
--- a/modules/standards/bin/functions.sh
+++ b/modules/standards/bin/functions.sh
@@ -23,7 +23,7 @@ function generate_list_of_links() {
     .[]
     | .status
     |= ( {"draft": "{draft}", "obsolete": "{obsolete}"}[.] // "{active}" )
-    | "* [[" + .asciidocfile + "_" + $suffix + "]] xref:" + .asciidocfile + "[" + .title + "] " + .status
+    | "* [[" + .asciidocfile + "_" + $suffix + "]] xref:" + .asciidocfile + "[" + .title + "]{nbsp}" + .status
    '
 }
 


### PR DESCRIPTION
A non-breaking space has been introduced
to avoid a linkebreak between the title
and the status of the document on small
screens.